### PR TITLE
java.io.tmpdir does not return a trailing slash on all OS consistently

### DIFF
--- a/src/main/java/magpiebridge/util/MessageLogger.java
+++ b/src/main/java/magpiebridge/util/MessageLogger.java
@@ -22,6 +22,10 @@ public final class MessageLogger {
 
   public MessageLogger() {
     String tempDir = System.getProperty("java.io.tmpdir");
+    String seperator = System.getProperty("file.separator");
+    if (!tempDir.endsWith(seperator)){
+      tempDir += seperator;
+    }
     String suffix = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date()) + ".log";
     log = new File(tempDir + "magpie_trace_" + suffix);
     try {


### PR DESCRIPTION
i.e. on some Operating Systems (Linux, WinXP(?)) Logger tries to access a file one directory level above the temporary directory - which on Linux is usually the root filesystem and thats normally not writeable for the normal user.