### PR TITLE
Fix NPE when didSave is called and server.client is null

### DIFF
--- a/src/main/java/magpiebridge/core/MagpieTextDocumentService.java
+++ b/src/main/java/magpiebridge/core/MagpieTextDocumentService.java
@@ -110,8 +110,10 @@ public class MagpieTextDocumentService implements TextDocumentService {
   public void didSave(DidSaveTextDocumentParams params) {
     if (server.config.doAnalysisBySave()) {
       server.cleanUp();
-      server.client.showMessage(
-          new MessageParams(MessageType.Info, "The analyzer started re-analyzing the code."));
+      if (server.client != null) {
+        server.client.showMessage(
+            new MessageParams(MessageType.Info, "The analyzer started re-analyzing the code."));
+      }
       // re-analyze when file is saved.
       String language = inferLanguage(params.getTextDocument().getUri());
       server.doAnalysis(language, true);


### PR DESCRIPTION
The method `didSave` in the class **MagpieTextDocumentService** runs into a NPE when `server.client` is null. In the same class, the method `didOpen` is able to cope with that. I believe that adding a null check to `didSave` will make the code more consistent and easier to test - you don't need to set-up a client before calling `didSave` when writing unit tests.