### PR TITLE
fix stdio jsonrpc communication

### DIFF
--- a/src/main/java/magpiebridge/command/OpenURLCommand.java
+++ b/src/main/java/magpiebridge/command/OpenURLCommand.java
@@ -67,12 +67,16 @@ public class OpenURLCommand implements WorkspaceCommand {
       if (Desktop.isDesktopSupported()) {
         // disable stdout from browser as it corrupts jsonrpc stdio communication
         PrintStream original = System.out;
-        try{
-          System.setOut(new PrintStream(new OutputStream() {
-            public void write(int b) { }
-          }));
+        try {
+          PrintStream devnull = new PrintStream(
+                  new OutputStream() {
+                    public void write(int b) {
+                    }
+                  });
+          System.setErr(devnull);
+          System.setOut(devnull);
           Desktop.getDesktop().browse(new URI(URIUtils.checkURI(uri)));
-        }catch (Exception e){
+        } catch (Exception e) {
           e.printStackTrace();
         }
         System.setOut(original);

--- a/src/main/java/magpiebridge/command/OpenURLCommand.java
+++ b/src/main/java/magpiebridge/command/OpenURLCommand.java
@@ -79,7 +79,7 @@ public class OpenURLCommand implements WorkspaceCommand {
         } catch (Exception e) {
           e.printStackTrace();
         }
-        System.setOut(original);
+        // System.setOut(original);
       }
     }
   }

--- a/src/main/java/magpiebridge/command/OpenURLCommand.java
+++ b/src/main/java/magpiebridge/command/OpenURLCommand.java
@@ -3,6 +3,8 @@ package magpiebridge.command;
 import com.google.gson.JsonPrimitive;
 import java.awt.Desktop;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -62,8 +64,19 @@ public class OpenURLCommand implements WorkspaceCommand {
         ((MagpieClient) client).showHTML(content);
       }
     } else {
-      if (Desktop.isDesktopSupported())
-        Desktop.getDesktop().browse(new URI(URIUtils.checkURI(uri)));
+      if (Desktop.isDesktopSupported()) {
+        // disable stdout from browser as it corrupts jsonrpc stdio communication
+        PrintStream original = System.out;
+        try{
+          System.setOut(new PrintStream(new OutputStream() {
+            public void write(int b) { }
+          }));
+          Desktop.getDesktop().browse(new URI(URIUtils.checkURI(uri)));
+        }catch (Exception e){
+          e.printStackTrace();
+        }
+        System.setOut(original);
+      }
     }
   }
 }

--- a/src/main/java/magpiebridge/util/ExceptionLogger.java
+++ b/src/main/java/magpiebridge/util/ExceptionLogger.java
@@ -37,7 +37,8 @@ public class ExceptionLogger {
     if (log == null) {
       String suffix = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date()) + ".log";
       log = new File(tempDir + "magpie_exceptions_" + suffix);
-      System.err.println("Log file path: " + log.getAbsolutePath());
+
+      // System.err.println("Log file path: " + log.getAbsolutePath());
     }
     try {
       logStream = new FileOutputStream(log);
@@ -83,7 +84,7 @@ public class ExceptionLogger {
       server.forwardMessageToClient(new MessageParams(MessageType.Warning, msg));
     String timeStamp = new SimpleDateFormat("[yyyy-MM-dd HH:mm:ss:SS]").format(new Date());
     writer.println(timeStamp + msg);
-    if (debug) System.err.println(msg);
+   // if (debug) System.err.println(msg);
   }
 
   public void cleanUp() {


### PR DESCRIPTION
setting:
1) Control-Panel opens in a (new) browser instance.
2) Communication channel is set to stdio

Now if the browser instance is jabbering on stdio then jsonrpc is confused and e.g. vscode is waiting for a response from the language server which the language server has already given to the language client.

https://github.com/swissiety/JimpleLSP/issues/22

TODO
- [ ] verify fix