### PR TITLE
Experiment/fluent tql magpie

### DIFF
--- a/src/main/java/magpiebridge/projectservice/java/Artifact.java
+++ b/src/main/java/magpiebridge/projectservice/java/Artifact.java
@@ -10,12 +10,20 @@ import magpiebridge.core.MagpieServer;
  * @author Linghui Luo
  */
 public class Artifact {
-  protected final String groupId, artifactId, version;
+  protected final String groupId, artifactId, version, classifier;
 
   public Artifact(String groupId, String artifactId, String version) {
     this.groupId = groupId;
     this.artifactId = artifactId;
     this.version = version;
+    this.classifier = "";
+  }
+
+  public Artifact(String groupId, String artifactId, String version, String classifier) {
+    this.groupId = groupId;
+    this.artifactId = artifactId;
+    this.version = version;
+    this.classifier = classifier;
   }
 
   public static Artifact parse(String id) {
@@ -42,12 +50,13 @@ public class Artifact {
     Artifact artifact = (Artifact) o;
     return Objects.equals(groupId, artifact.groupId)
         && Objects.equals(artifactId, artifact.artifactId)
-        && Objects.equals(version, artifact.version);
+        && Objects.equals(version, artifact.version)
+        && Objects.equals(classifier, artifact.classifier);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(groupId, artifactId, version);
+    return Objects.hash(groupId, artifactId, version, classifier);
   }
 
   @Override

--- a/src/main/java/magpiebridge/projectservice/java/InferConfig.java
+++ b/src/main/java/magpiebridge/projectservice/java/InferConfig.java
@@ -341,7 +341,8 @@ public class InferConfig {
     Path jar =
         mavenHome
             .resolve("repository")
-            .resolve(artifact.groupId.replace('.', File.separatorChar))
+            .resolve(
+                artifact.groupId.replace('.', File.separatorChar).replace(':', File.separatorChar))
             .resolve(artifact.artifactId)
             .resolve(artifact.version)
             .resolve(fileNameJar(artifact, source));

--- a/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
+++ b/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
@@ -1,0 +1,25 @@
+package magpiebridge.projectservice.java;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertTrue;
+
+public class FiveColonTest {
+    /**
+     * Test for the project that contains a library with a classifier.
+     * In our test case "DemoProjectForFiveColon, we have a library javafx.base with the classifier win, in this case mvn dependency:list
+     * produces output with 5 colon format. Then the jar filename format is [artifcatid]-[version]-[classifier].jar
+     * e.g. javafx-base-17-ea+8-win.jar
+     */
+    @Test
+    public void test1() {
+        Path root = Paths.get("src/test/resources/DemoProjectForFiveColon").toAbsolutePath();
+
+        InferConfig inferConfig = new InferConfig(root);
+
+        assertTrue(inferConfig.libraryClassPath().toArray()[0].toString().endsWith("javafx-base-17-ea+8-win.jar"));
+    }
+}

--- a/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
+++ b/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
@@ -21,6 +21,8 @@ public class FiveColonTest {
         InferConfig inferConfig = new InferConfig(root);
 
         System.out.println(inferConfig.libraryClassPath());
-        assertTrue(inferConfig.libraryClassPath().toArray()[0].toString().endsWith("javafx-base-17-ea+8-win.jar"));
+        assertTrue(inferConfig.libraryClassPath().toArray()[0].toString().endsWith("javafx-base-17-ea+8-linux.jar"));
+        assertTrue(inferConfig.libraryClassPath().toArray()[1].toString().endsWith("javafx-base-17-ea+8-win.jar"));
+        assertTrue(inferConfig.libraryClassPath().toArray()[2].toString().endsWith("javafx-base-17-ea+8-mac.jar"));
     }
 }

--- a/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
+++ b/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
 
 import static org.junit.Assert.assertTrue;
 
@@ -20,9 +22,12 @@ public class FiveColonTest {
 
         InferConfig inferConfig = new InferConfig(root);
 
-        System.out.println(inferConfig.libraryClassPath());
-        assertTrue(inferConfig.libraryClassPath().toArray()[0].toString().endsWith("javafx-base-17-ea+8-linux.jar"));
-        assertTrue(inferConfig.libraryClassPath().toArray()[1].toString().endsWith("javafx-base-17-ea+8-win.jar"));
-        assertTrue(inferConfig.libraryClassPath().toArray()[2].toString().endsWith("javafx-base-17-ea+8-mac.jar"));
+        ArrayList<Path> libPath = new ArrayList<Path>(inferConfig.libraryClassPath());
+        Collections.sort(libPath);
+
+        System.out.println(libPath);
+        assertTrue(libPath.get(0).toString().endsWith("javafx-base-17-ea+8-linux.jar"));
+        assertTrue(libPath.get(1).toString().endsWith("javafx-base-17-ea+8-mac.jar"));
+        assertTrue(libPath.get(2).toString().endsWith("javafx-base-17-ea+8-win.jar"));
     }
 }

--- a/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
+++ b/src/test/java/magpiebridge/projectservice/java/FiveColonTest.java
@@ -20,6 +20,7 @@ public class FiveColonTest {
 
         InferConfig inferConfig = new InferConfig(root);
 
+        System.out.println(inferConfig.libraryClassPath());
         assertTrue(inferConfig.libraryClassPath().toArray()[0].toString().endsWith("javafx-base-17-ea+8-win.jar"));
     }
 }

--- a/src/test/resources/DemoProjectForFiveColon/.gitignore
+++ b/src/test/resources/DemoProjectForFiveColon/.gitignore
@@ -1,0 +1,3 @@
+.idea
+*.iml
+target

--- a/src/test/resources/DemoProjectForFiveColon/pom.xml
+++ b/src/test/resources/DemoProjectForFiveColon/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/src/test/resources/DemoProjectForFiveColon/pom.xml
+++ b/src/test/resources/DemoProjectForFiveColon/pom.xml
@@ -21,5 +21,21 @@
             <version>17-ea+8</version>
             <classifier>win</classifier>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-base -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>17-ea+8</version>
+            <classifier>mac</classifier>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-base -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>17-ea+8</version>
+            <classifier>linux</classifier>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/resources/DemoProjectForFiveColon/pom.xml
+++ b/src/test/resources/DemoProjectForFiveColon/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>DemoProjectForFiveColon</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.openjfx/javafx-base -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>17-ea+8</version>
+            <classifier>win</classifier>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/DemoProjectForFiveColon/src/main/java/DummyMain.java
+++ b/src/test/resources/DemoProjectForFiveColon/src/main/java/DummyMain.java
@@ -1,0 +1,5 @@
+public class DummyMain {
+    public static void main(String[] args) {
+        System.out.println("Dummy project");
+    }
+}


### PR DESCRIPTION
Hi,

Sometimes, If the project specifies a classifier in the pom file, then "mvn dependency:list" will give a row with a 5 ':' pattern, then the library path will contain a ':' that produces an illegal character exception. This PR contains a fix to this issue.

Solution: 
In the pattern matcher, it checks if it has 5 colons, then creates a path accordingly with the classifier, otherwise, it goes with normal 4 ':'. Otherwise, it replaces all ':' with File separator to avoid the illegal character exception.

Thanks,
Ranjith