### PR TITLE
add language support for LLVM

### DIFF
--- a/src/main/java/magpiebridge/core/MagpieTextDocumentService.java
+++ b/src/main/java/magpiebridge/core/MagpieTextDocumentService.java
@@ -232,6 +232,8 @@ public class MagpieTextDocumentService implements TextDocumentService {
       return "c++";
     } else if (uri.endsWith(".c")) {
       return "c";
+    } else if (uri.endsWith(".ll")) {
+      return "ll";
     } else {
       MagpieServer.ExceptionLogger.log("Couldn't infer the language of the source code in " + uri);
       return "unknown";

--- a/src/main/java/magpiebridge/file/SourceFileManager.java
+++ b/src/main/java/magpiebridge/file/SourceFileManager.java
@@ -197,8 +197,11 @@ public class SourceFileManager {
     } else if (language.equals("javascript") || language.equals("js")) {
       return ".js";
     } else if (language.equals("c")) return ".c";
-    else if (language.equals("typescript") || language.equals("ts")) return ".ts";
-    else {
+      else if (language.equals("typescript") || language.equals("ts")) return ".ts";
+      else if (language.equals("llvm") || language.equals("ll")) {
+      return ".ll";
+    }
+      else {
       MagpieServer.ExceptionLogger.log("Unsupported language: " + language);
       return "unknown";
     }


### PR DESCRIPTION
We want to make vscode extension for our LLVM analysis using MagpieBridge.
We got an error saying "couldn't infer the language of the source code".
